### PR TITLE
Update tangram to 0.3.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
     <!-- End of 3rd party libraries -->
 
     <!-- Main tangram library -->
-    <script src="https://mapzen.com/tangram/0.3.0/tangram.min.js"></script>
+    <script src="https://mapzen.com/tangram/0.3.1/tangram.min.js"></script>
 
 	<!-- Keymaster handles keyboard input -->
     <script src="lib/keymaster.js"></script>


### PR DESCRIPTION
Fixes a path bug affecting some of the standalone demos.

Bug was **not** visible when loading from a path such as:

http://nvkelso.github.io/tangram-skin-and-bones/#15.91625/37.8035/-122.2695

But **is** visible when loading from direct file, notice missing POIs:

http://nvkelso.github.io/tangram-skin-and-bones/index.html#15.91625/37.8035/-122.2695

Resolved in 0.3.1:

http://bcamper.github.io/tangram-skin-and-bones/index.html#15.91625/37.8035/-122.2695
